### PR TITLE
fix: Don't do stuff in on_ready part 2 electric boogaloo

### DIFF
--- a/api/routers/discord.py
+++ b/api/routers/discord.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter,  HTTPException
 import threading
 import asyncio
-from bot_run import client
+from bot_run import client, start_bot
 from src.data.config_data import load_or_create_config
 router = APIRouter()
 _bot_thread = None
@@ -11,12 +11,11 @@ _bot_loop = None
 def _run_bot():
     global _bot_loop
     config = load_or_create_config()
-    discord_token = config.discord_key
     # Using a new event loop in this thread
     _bot_loop = asyncio.new_event_loop()
     asyncio.set_event_loop(_bot_loop)
     try:
-        _bot_loop.run_until_complete(client.start(discord_token))
+        _bot_loop.run_until_complete(start_bot(config))
     except Exception as e:
         print(f'Bot crashed: {e}')
     finally:

--- a/bot_run.py
+++ b/bot_run.py
@@ -237,10 +237,13 @@ def setup_bot():
     setup_commands()
 
 async def start_bot(config: conf.Config):
-    # Kick off background thinking loop
-    asyncio.create_task(pipeline.think())
+    if config.discord_key:
+        # Kick off background thinking loop
+        asyncio.create_task(pipeline.think())
 
-    await client.start(config.discord_key)
+        await client.start(config.discord_key)
+    else:
+        raise Exception("Discord Bot Key Empty")
 
 @client.event
 async def on_ready():

--- a/src/controller/pipeline.py
+++ b/src/controller/pipeline.py
@@ -2,6 +2,8 @@ import asyncio
 from src.controller.config import queue_to_process_everything
 import discord
 import os
+import sys
+import traceback
 from src.models.aicharacter import AICharacter
 from src.models.dimension import Dimension
 from src.models.prompts import PromptEngineer
@@ -12,6 +14,15 @@ from src.utils.image_gen import generate_sd_prompt
 from src.utils.pollination import fetch_image
 from src.utils.hidream import invoke_chute
 from src.utils.duckduckgo import research,image_research
+
+def format_traceback(error: Exception, *, _print: bool = False) -> str:
+    # https://github.com/InterStella0/stella_bot/blob/896c94e847829575d4699c0dd9d9b925d01c4b44/utils/useful.py#L132~L140
+    if _print:
+        traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+    etype = type(error)
+    trace = error.__traceback__
+    lines = traceback.format_exception(etype, error, trace)
+    return "".join(lines)
 
 # GOD Refactoring this gonna be a bitch and a half...
 
@@ -85,7 +96,7 @@ async def think() -> None:
             else:
                 await send_llm_message(bot,message,dimension, plugin="") # Prepping up to make plugins easier to handle, maybe
         except Exception as e:
-            print(f"Something went wrong: {e}")
+            print(f"Something went wrong: {format_traceback(e)}")
             try:
                 await message.add_reaction('❌')
             except Exception as e:


### PR DESCRIPTION
Basically the same as previous `on_ready` refactor but it actually do stuff now.

* `start_pipeline` -> `start_bot`, so we have more control over `client.start(...)`, use this function as alternative to `on_ready` whenever possible
* I still keep some stuff in `on_ready`, like `conf.bot_user = client.user`, cuz obviously we want to keep track of the latest account the bot is logged into, and `tree.sync(...)` cuz I can't be bothered to touch the CMS to make the sync to be on demand
* I moved the config loading in `bot_run.py` into the `__main__` if statement cuz that's the only place it has been used and the rest of them is handled by the CMS' API handler so it basically useless for anything other than `__main__`
* Something went wrong, where?!? print the dang traceback!!! no wonder it's painful for you debug this shit

I tested it but Viel keep complaining about "No matching cord found" so idk if it actually work or not.