### PR TITLE
fix: Remove the bot name from the search query

### DIFF
--- a/src/models/prompts.py
+++ b/src/models/prompts.py
@@ -6,6 +6,8 @@ from src.utils.bot_thonk import extract_plugin_docs_as_string
 from src.utils.duckduckgo import research
 import discord
 import random
+import re
+# wtf? are you allergic to using caps or somethin?
 true = True
 false = False
 class PromptEngineer:
@@ -30,7 +32,7 @@ class PromptEngineer:
             try:
                 search_query = self.message.content.replace("search>","")
                 search_query = search_query.lower()
-                search_query = search_query.replace(self.bot.bot_name.lower(),"") # Wait, why is it not working???
+                search_query = re.sub(re.escape(self.bot.bot_name.lower()), "", search_query, flags=re.I)
                 #print(search_query)
                 search_result = await research(search_query)
                 instructionvar+=search_result


### PR DESCRIPTION
Idk if you already figure this out on your local machine but to answer your question in the comment, it's cuz you try to remove "viel" when the bot name in the search query is "Viel". Have you try coffee? or tea perhaps? or maybe energy drink?